### PR TITLE
ci: remove AWS deployment

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -41,13 +41,6 @@ jobs:
         with:
           node-version: 18
 
-      - name: Configure AWS credentials for prod
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.UPDATES_PROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.UPDATES_PROD_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
       - name: Set env
         run: |
           echo "YARI_BRANCH=${{ inputs.yari_branch || env.DEFAULT_YARI_BRANCH }}" >> $GITHUB_ENV

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -40,13 +40,6 @@ jobs:
         with:
           node-version: 18
 
-      - name: Configure AWS credentials for stage
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.UPDATES_STAGE_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.UPDATES_STAGE_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
       - name: Set env
         run: |
           echo "YARI_BRANCH=${{ inputs.yari_branch || env.DEFAULT_YARI_BRANCH }}" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ update.json
 ## Automating and Uploading Artifacts
 
 We include a shell script that automates everything we need to generate
-the latest bundles. And then uploads it to S3 for distribution.
+the latest bundles. And then uploads it to GCS for distribution.
 
 Take a look at [scripts/run.sh](scripts/run.sh)
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -85,11 +85,6 @@ differy package $BUILD_OUT_ROOT --rev $REV
 cp update.json ${REV}-update.json
 cp ${REV}-content.json content.json
 
-aws s3 cp . s3://${BUCKET}/packages/ --recursive --exclude "*" --include "${REV}-*.zip"
-aws s3 cp . s3://${BUCKET}/packages/ --recursive --exclude "*" --include "${REV}-*.json"
-aws s3 cp update.json s3://${BUCKET}/
-aws s3 cp content.json s3://${BUCKET}/
-
 # Sync to GCP
 gsutil -m -h "Cache-Control:public, max-age=86400" cp "${REV}-*.zip" gs://${GCS_BUCKET}/packages/
 gsutil -m -h "Cache-Control:public, max-age=86400" cp "${REV}-*.json" gs://${GCS_BUCKET}/packages/


### PR DESCRIPTION
We have migrated `updates.developer.mozilla/allizom.org` to GCP, so we no longer need to deploy to AWS.

Part of MP-312.