### PR TITLE
chore: use live-samples subdomain

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -49,7 +49,7 @@ fi
 cd $WORKBENCH
 export CONTENT_ROOT=$WORKBENCH/content
 export BUILD_OUT_ROOT=$WORKBENCH/build
-export BUILD_LIVE_SAMPLES_BASE_URL="https://yari-demos.prod.mdn.mozit.cloud"
+export BUILD_LIVE_SAMPLES_BASE_URL="https://live-samples.mdn.mozilla.net"
 mkdir -p $BUILD_OUT_ROOT
 
 cd $WORKBENCH/yari

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -12,7 +12,7 @@ const APP_REPLACEMENTS: &[(&str, &str)] = &[
         "src=\\\"mdn-app://examples/examples",
     ),
     (
-        "src=\\\"https://yari-demos.prod.mdn.mozit.cloud",
+        "src=\\\"https://live-samples.mdn.mozilla.net",
         "src=\\\"mdn-app://yari-demos",
     ),
 ];
@@ -22,10 +22,7 @@ const WEB_REPLACEMENTS: &[(&str, &str)] = &[
         "src=\\\"https://interactive-examples.mdn.mozilla.net",
         "src=\\\"/examples",
     ),
-    (
-        "src=\\\"https://yari-demos.prod.mdn.mozit.cloud",
-        "src=\\\"",
-    ),
+    ("src=\\\"https://live-samples.mdn.mozilla.net", "src=\\\""),
 ];
 
 pub fn replace(input: String, replace: &[(&str, &str)]) -> String {
@@ -188,7 +185,7 @@ mod test {
 
     #[test]
     fn test_replace_web() {
-        let raw = r#"<iframe src=\"https://yari-demos.prod.mdn.mozit.cloud/foo\">"#;
+        let raw = r#"<iframe src=\"https://live-samples.mdn.mozilla.net/foo\">"#;
         let out = replace_all_web(raw.to_string());
         assert_eq!(r#"<iframe src=\"/foo\">"#, &out);
         let raw = r#"<iframe src=\"https://interactive-examples.mdn.mozilla.net/foo\">"#;

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -13,7 +13,7 @@ const APP_REPLACEMENTS: &[(&str, &str)] = &[
     ),
     (
         "src=\\\"https://live-samples.mdn.mozilla.net",
-        "src=\\\"mdn-app://yari-demos",
+        "src=\\\"mdn-app://live-samples",
     ),
 ];
 


### PR DESCRIPTION
Previously, live samples have been hosted at https://yari-demos.prod.mdn.mozit.cloud, but in the future they will be hosted at ~~https://live-samples.mdn.mozit.cloud~~ https://live-samples.mdn.mozilla.net.

Part of MP-319.