### PR TITLE
ci(workflows): disable `actions/checkout` credential persistance

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -53,7 +53,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Do it!
-        env: 
+        env:
           UPDATE_URL: https://updates.developer.mozilla.org
           BUCKET: updates-prod-developer-mozilla-e2b95ed55d379b1a
           GCS_BUCKET: updates-prod-mdn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: taiki-e/create-gh-release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -18,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: differy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run fmt
         run: cargo fmt -- --check
       - name: Build

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -53,7 +53,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Do it!
-        env: 
+        env:
           UPDATE_URL: https://updates.developer.allizom.org
           BUCKET: updates-stage-developer-allizom-6d533edfe2c2c683
           GCS_BUCKET: updates-stage-mdn


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
  
Adds `persist-credentials: false` to all `actions/checkout` workflow steps.

## Motivation

Applies security best practices. It prevents persistance of the `GITHUB_TOKEN` in the local git config.

### Additional details

Follow-up of https://github.com/mdn/differy/pull/34, which was incomplete.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/883.
