### PR TITLE
ci(workflows): disable automatic setup-node caching

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          package-manager-cache: false
 
       - name: Authenticate with GCP
         uses: google-github-actions/auth@v2

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          package-manager-cache: false
 
       - name: Authenticate with GCP
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
### Description

Sets `package-manager-cache: false` to all `actions/setup-node` workflow steps that don't already have caching configured via either `package-manager-cache` or `cache`.

### Motivation

The new default behavior introduced in [`actions/setup-node v5.0.0`](https://github.com/actions/setup-node/releases/tag/v5.0.0) is not safe.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
